### PR TITLE
WHO MR fix

### DIFF
--- a/R/gho_mortality.R
+++ b/R/gho_mortality.R
@@ -74,7 +74,7 @@ get_who_mr_memo <- function(age, sex = NULL, region = NULL, country = NULL,
     )
   }
   ages_gho <- trans_age_gho(age)
-  age_gho <- if ("AGE100+" %in% mr_data$AGEGROUP){
+  age_gho <- if ("YEARS100+" %in% mr_data$AGEGROUP){
     ages_gho[[1]]
   } else {
     ages_gho[[2]]  
@@ -242,17 +242,17 @@ trans_age_gho <- function(age) {
   )
   labs <- list(
     c(
-      "AGELT1", "AGE1-4", "AGE5-9",
-      "AGE10-14", "AGE15-19", "AGE20-24",
-      "AGE25-29", "AGE30-34", "AGE35-39",
-      "AGE40-44", "AGE45-49", "AGE50-54",
-      "AGE55-59", "AGE60-64", "AGE65-69",
-      "AGE70-74", "AGE75-79", "AGE80-84",
-      "AGE85-89", "AGE90-94", "AGE95-99",
-      "AGE100+"
+      "YEARSLT1", "YEARS1-4", "YEARS5-9",
+      "YEARS10-14", "YEARS15-19", "YEARS20-24",
+      "YEARS25-29", "YEARS30-34", "YEARS35-39",
+      "YEARS40-44", "YEARS45-49", "YEARS50-54",
+      "YEARS55-59", "YEARS60-64", "YEARS65-69",
+      "YEARS70-74", "YEARS75-79", "YEARS80-84",
+      "YEARS85-89", "YEARS90-94", "YEARS95-99",
+      "YEARS100+"
     )
   )
-  labs[[2]] <- c(labs[[1]][1:18], "AGE85PLUS")
+  labs[[2]] <- c(labs[[1]][1:18], "YEARS85PLUS")
   
   breaks <- list(
     c(0, 1, seq(5, 100, 5), +Inf),

--- a/R/gho_mortality.R
+++ b/R/gho_mortality.R
@@ -158,7 +158,7 @@ get_gho_mr <- function(sex, region, country, year) {
   }
   
   if (is.null(sex)) {
-    mr_data_year <- dplyr::filter(mr_data_year, .data$SEX == "BTSX")
+    mr_data_year <- dplyr::filter(mr_data_year, .data$SEX == "SEX_BTSX")
   }
 
   mr_data_year


### PR DESCRIPTION
* Resolves #16 
* get_who_mr function was returning NA
  * This was because of the format change in  `rgho::get_gho_data`
  * Changed "**AGE**" to "**YEARS**" in `trans_age_gho`
  * Also changed "BTSX" to "SEX_BTSX" for filtering
* Currently the _get_who_mr_ functions works as expected, might need to watch for other breaking changes in data format.
* Ran the tests, all except one is successful:
```
  ══ Skipped tests (1) ═══════════════════════════════════════════════════════════════════════════════════════════════════════
• empty test (1): test_starting_values.R:200:1

══ Failed tests ════════════════════════════════════════════════════════════════════════════════════════════════════════════
── Error (test_surv_psa.R:269:4): errors run_psa resample ──────────────────────
<purrr_error_indexed/rlang_error/error/condition>
Error in `map(psa$surv, function(x) {
    var <- getOption("heemod.env")[[x]]
    if (!inherits(var, c("surv_dist", "surv_fit"))) {
        cli::cli_abort("{.var {x}} must be a {.cls surv_fit} or {.cls surv_dist} object, i.e the initial survival \\\n      distribution before the modification leading to the creation of a {.cls {class(var)[[1]]}} object")
    }
})`: i In index: 1.
Caused by error in `.f()`:
! `km_2` must be a <surv_fit> or <surv_dist> object, i.e the initial survival distribution before the modification leading to the creation of a <surv_model> object

[ FAIL 1 | WARN 0 | SKIP 1 | PASS 509 ]
Error: Test failures
```
  * Seems unrelated to the updates